### PR TITLE
fix: dump profiler logs to a file

### DIFF
--- a/snap/local/command-wrapper
+++ b/snap/local/command-wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# we need to enable service.profilesSupport feature gate to use the profiles pipeline
+FEATURE_GATES="--feature-gates service.profilesSupport"
+DEFAULT_CONFIG_FILE="/etc/otel-ebpf-profiler/config.yaml"
+DEFAULT_LOG_FILE="/var/log/otel-ebpf-profiler.log"
+
+exec "$SNAP/bin/otel-ebpf-profiler" $FEATURE_GATES "--config" "$DEFAULT_CONFIG_FILE" 2>&1  | tee -a $DEFAULT_LOG_FILE

--- a/snap/local/command-wrapper
+++ b/snap/local/command-wrapper
@@ -5,4 +5,5 @@ FEATURE_GATES="--feature-gates service.profilesSupport"
 DEFAULT_CONFIG_FILE="/etc/otel-ebpf-profiler/config.yaml"
 DEFAULT_LOG_FILE="/var/log/otel-ebpf-profiler.log"
 
+# redirect both stdout and stderr to $DEFAULT_LOG_FILE
 exec "$SNAP/bin/otel-ebpf-profiler" $FEATURE_GATES "--config" "$DEFAULT_CONFIG_FILE" 2>&1  | tee -a $DEFAULT_LOG_FILE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,11 +19,17 @@ confinement: classic
 apps:
   otel-ebpf-profiler:
     daemon: simple
-    # we need to enable service.profilesSupport feature gate to use the profiles pipeline
-    command: /bin/otel-ebpf-profiler --feature-gates service.profilesSupport --config /etc/otel-ebpf-profiler/config.yaml
+    # command: /bin/otel-ebpf-profiler --feature-gates service.profilesSupport --config /etc/otel-ebpf-profiler/config.yaml 2>&1  | tee -a "/var/log/otel-ebpf-profiler.log"
+    command: command-wrapper 
     install-mode: disable
     restart-condition: on-failure
 parts:
+  wrapper:
+    plugin: dump
+    source: ./snap/
+    source-type: local
+    override-build: |
+      install -D local/command-wrapper $CRAFT_PART_INSTALL/
   config:
     plugin: dump
     source: ./snap/


### PR DESCRIPTION
## Issue
For classic snaps, `opentelemetry-collector`/`grafana-agent` charms look for log files inside the `/var/log/**` directory. 

## Solution
Redirect the profiler logs (stdout and stderr) to `/var/log/otel-ebpf-profiler.log` so that `cos_agent` can scrape the profiler workload logs