### PR TITLE
feat: add release workflow + pull binary from artifact

### DIFF
--- a/.github/workflows/_build-and-test-snap.yaml
+++ b/.github/workflows/_build-and-test-snap.yaml
@@ -1,0 +1,37 @@
+name: Build and Test Snap
+
+on:
+  workflow_call:
+
+jobs:
+  build-snap:
+    name: Build Snap
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'Ubuntu_ARM64_4C_16G_03' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.3
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          sudo snap install yq
+          sudo snap install just --classic
+
+      - name: Pack Snap
+        run: snapcraft pack -v
+
+      - name: Smoke Test
+        run: just smoke
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: ./*.snap

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,28 +1,12 @@
 # Build and test the snap on pull_request to ensure the snap is functional before merging to main
-name: Build and Test Snap
+name: Pull Request
 
 on:
   pull_request:
 
 jobs:
   build-and-test:
-    name: Build classic snap
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'Ubuntu_ARM64_4C_16G_03' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.3
-
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic --channel edge snapcraft
-          sudo snap install yq
-          sudo snap install just --classic
-      - name: Build & Test Snap 
-        run: just smoke
+    name: Quality Checks
+    uses: ./.github/workflows/_build-and-test-snap.yaml
+    secrets: inherit
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'Ubuntu_ARM64_4C_16G_03' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -12,27 +12,22 @@ env:
   SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
 jobs:
-  build-and-release:
-    name: Build & release classic snap
+  build-and-test:
+    name: Quality Checks
+    uses: ./.github/workflows/_build-and-test-snap.yaml
+    secrets: inherit
+  release-snaps:
+    needs:
+    - build-and-test
     strategy:
-        matrix:
-          arch: [amd64, arm64]
-    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'Ubuntu_ARM64_4C_16G_03' }}
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.3
-
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic --channel edge snapcraft
-          sudo snap install yq
-          sudo snap install just --classic
-
-      - name: Pack Snap
-        run: snapcraft pack -v
-
-      - name: Upload and Publish Snap
-        run: snapcraft upload --release edge otel-ebpf-profiler_*_*.snap
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: .
+      - name: Upload and release snap
+        run: snapcraft upload --release edge otel-ebpf-profiler_*_${{ matrix.arch }}.snap

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -1,0 +1,38 @@
+# Build and release the snap on merge to main
+
+name: Release Snap
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+jobs:
+  build-and-release:
+    name: Build & release classic snap
+    strategy:
+        matrix:
+          arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'Ubuntu_ARM64_4C_16G_03' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.3
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          sudo snap install yq
+          sudo snap install just --classic
+
+      - name: Pack Snap
+        run: snapcraft pack -v
+
+      - name: Upload and Publish Snap
+        run: snapcraft upload --release edge otel-ebpf-profiler_*_*.snap

--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -38,17 +38,9 @@ jobs:
         shell: bash
         run: |
           release=$(yq '.version' $GITHUB_WORKSPACE/main/snap/snapcraft.yaml)
-          latest=${{steps.latest-release.outputs.release}}
-
-          # Skip if the latest release is a nightly
-          if [[ "$latest" == *"nightly"* ]]; then
-            echo "Latest release $latest is a nightly, skipping."
-            exit 0
-          fi
-          
-          if [ "$release" != "$latest" ]; then
-            echo "release=$latest" >> $GITHUB_OUTPUT
-            echo "New upstream release $latest found"
+          if [ "${release}" != "${{steps.latest-release.outputs.release}}" ]; then
+            echo "release=${{steps.latest-release.outputs.release}}" >> $GITHUB_OUTPUT
+            echo "New upstream release ${{steps.latest-release.outputs.release}} found"
           else
             echo "No new upstream release found"
           fi

--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -38,9 +38,17 @@ jobs:
         shell: bash
         run: |
           release=$(yq '.version' $GITHUB_WORKSPACE/main/snap/snapcraft.yaml)
-          if [ "${release}" != "${{steps.latest-release.outputs.release}}" ]; then
-            echo "release=${{steps.latest-release.outputs.release}}" >> $GITHUB_OUTPUT
-            echo "New upstream release ${{steps.latest-release.outputs.release}} found"
+          latest=${{steps.latest-release.outputs.release}}
+
+          # Skip if the latest release is a nightly
+          if [[ "$latest" == *"nightly"* ]]; then
+            echo "Latest release $latest is a nightly, skipping."
+            exit 0
+          fi
+          
+          if [ "$release" != "$latest" ]; then
+            echo "release=$latest" >> $GITHUB_OUTPUT
+            echo "New upstream release $latest found"
           else
             echo "No new upstream release found"
           fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,8 +46,8 @@ parts:
     plugin: dump
     source-type: tar
     source: 
-      - to amd64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.131.0/otelcol-ebpf-profiler_0.133.0_linux_amd64.tar.gz
-      - to arm64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.131.0/otelcol-ebpf-profiler_0.133.0_linux_arm64.tar.gz
+      - to amd64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.133.0/otelcol-ebpf-profiler_0.133.0_linux_amd64.tar.gz
+      - to arm64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.133.0/otelcol-ebpf-profiler_0.133.0_linux_arm64.tar.gz
       - else: fail
     override-build: |
       install -D -m755 otelcol-ebpf-profiler $SNAPCRAFT_PART_INSTALL/bin/otel-ebpf-profiler

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: otel-ebpf-profiler
 title: OpenTelemetry eBPF Profiler
-version: '0.131.0'
+version: '0.133.0'
 summary: Whole-system, cross-language profiler for Linux via eBPF.
 description: |
   An OpenTelemetry Collector distribution that is made specifically to be used as a whole-system,

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: otel-ebpf-profiler
 title: OpenTelemetry eBPF Profiler
-version: '0.130.0'
+version: '0.131.0'
 summary: Whole-system, cross-language profiler for Linux via eBPF.
 description: |
   An OpenTelemetry Collector distribution that is made specifically to be used as a whole-system,
@@ -42,33 +42,12 @@ parts:
     source-type: local
     override-build: |
       install -D config.yaml $CRAFT_PART_INSTALL/
-  ocb:
-    plugin: go
-    source: "https://github.com/open-telemetry/opentelemetry-collector.git"
-    source-type: "git"
-    source-tag: "v0.130.0"
-    source-depth: 1
-    source-subdir: "cmd/builder"
-    build-snaps:
-      - go/1.23/stable
-    build-environment:
-      - CGO_ENABLED: "0"
-      - GOOS: linux
-    stage:
-      - bin/builder
-    prime:
-      - "-*"
   ebpf-profiler:
-    after:
-      - ocb
     plugin: dump
-    source: .
-    build-packages:
-      - wget
+    source-type: tar
+    source: 
+      - to amd64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.131.0/otelcol-ebpf-profiler_0.133.0_linux_amd64.tar.gz
+      - to arm64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.131.0/otelcol-ebpf-profiler_0.133.0_linux_arm64.tar.gz
+      - else: fail
     override-build: |
-      # Create the binary
-      wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v0.130.0/distributions/otelcol-ebpf-profiler/manifest.yaml -O ${CRAFT_PART_BUILD}/manifest.yaml
-      builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
-      install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol-ebpf-profiler ${CRAFT_PART_INSTALL}/bin/otel-ebpf-profiler
-    build-attributes:
-      - enable-patchelf
+      install -D -m755 otelcol-ebpf-profiler $SNAPCRAFT_PART_INSTALL/bin/otel-ebpf-profiler

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,12 +42,33 @@ parts:
     source-type: local
     override-build: |
       install -D config.yaml $CRAFT_PART_INSTALL/
+  ocb:
+    plugin: go
+    source: "https://github.com/open-telemetry/opentelemetry-collector.git"
+    source-type: "git"
+    source-tag: "v0.133.0"
+    source-depth: 1
+    source-subdir: "cmd/builder"
+    build-snaps:
+      - go/1.23/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOOS: linux
+    stage:
+      - bin/builder
+    prime:
+      - "-*"
   ebpf-profiler:
+    after:
+      - ocb
     plugin: dump
-    source-type: tar
-    source: 
-      - to amd64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.133.0/otelcol-ebpf-profiler_0.133.0_linux_amd64.tar.gz
-      - to arm64: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.133.0/otelcol-ebpf-profiler_0.133.0_linux_arm64.tar.gz
-      - else: fail
+    source: .
+    build-packages:
+      - wget
     override-build: |
-      install -D -m755 otelcol-ebpf-profiler $SNAPCRAFT_PART_INSTALL/bin/otel-ebpf-profiler
+      # Create the binary
+      wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v0.133.0/distributions/otelcol-ebpf-profiler/manifest.yaml -O ${CRAFT_PART_BUILD}/manifest.yaml
+      builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
+      install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol-ebpf-profiler ${CRAFT_PART_INSTALL}/bin/otel-ebpf-profiler
+    build-attributes:
+      - enable-patchelf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,27 +35,24 @@ parts:
     source: ./snap/
     source-type: local
     override-build: |
-      install -D local/command-wrapper $CRAFT_PART_INSTALL/
+      install -D $CRAFT_PART_SRC/local/command-wrapper $CRAFT_PART_INSTALL/
   config:
     plugin: dump
     source: ./snap/
     source-type: local
     override-build: |
-      install -D config.yaml $CRAFT_PART_INSTALL/
+      install -D $CRAFT_PART_SRC/config.yaml $CRAFT_PART_INSTALL/
   ocb:
     plugin: go
     source: "https://github.com/open-telemetry/opentelemetry-collector.git"
     source-type: "git"
     source-tag: "v0.133.0"
     source-depth: 1
-    source-subdir: "cmd/builder"
     build-snaps:
       - go/1.24/stable
-    build-environment:
-      - CGO_ENABLED: "0"
-      - GOOS: linux
-    stage:
-      - bin/builder
+    override-build: |
+      cd cmd/builder
+      CGO_ENABLED=0 go build -trimpath -o ${CRAFT_PART_INSTALL}/bin/builder .
     prime:
       - "-*"
   ebpf-profiler:
@@ -68,8 +65,9 @@ parts:
     override-build: |
       # Create the binary
       wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v0.133.0/distributions/otelcol-ebpf-profiler/manifest.yaml -O ${CRAFT_PART_BUILD}/manifest.yaml
-      builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
+      # Starting from v0.0.202531, the eBPF profiler build no longer requires CGO.
+      # By disabling CGO, we ensure the resulting binary is fully static.
+      # This eliminates the linter warnings about missing dynamic linker.
+      CGO_ENABLED=0 builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol-ebpf-profiler ${CRAFT_PART_INSTALL}/bin/otel-ebpf-profiler
-    build-attributes:
-      - enable-patchelf
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,3 +72,4 @@ parts:
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol-ebpf-profiler ${CRAFT_PART_INSTALL}/bin/otel-ebpf-profiler
     build-attributes:
       - enable-patchelf
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,7 +50,7 @@ parts:
     source-depth: 1
     source-subdir: "cmd/builder"
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     build-environment:
       - CGO_ENABLED: "0"
       - GOOS: linux


### PR DESCRIPTION
Fixes #12 
Fixes #19 
- Add a release wf to release snap on edge for amd64 and arm64
- ~Update snapcraft.yaml to pull the profiler's binary directly from gh artifact instead of manually building it~ we'll continue building it ourselves